### PR TITLE
fix: change type create method return null #194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-### [4.0.5] - 2024-09-26
+### [4.0.5] - 2024-11-28
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [4.0.5] - 2024-09-26
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
+---
+
 ### [4.0.4] - 2024-09-26
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ export default class Money extends ValueObject<Props> {
     }
 
     // factory method to create an instance and validate value.
-    public static create(amount: number): Result<Money> {
+    public static create(amount: number): Result<Money | null> {
 
         const isValid = this.isValidProps({ amount });
         if(!isValid) return Fail("Invalid amount for money");
@@ -286,7 +286,7 @@ console.log(resA.isOk());
 
 
 // money instance
-const moneyA = resA.value();
+const moneyA = resA.value() as Money;
 
 moneyA.get("amount"); 
 
@@ -297,7 +297,7 @@ moneyA.isGt(Money.zero());
 
 // > true
 
-const moneyB = Money.create(100).value();
+const moneyB = Money.create(100).value() as Money;
 
 const moneyC = moneyA.sum(moneyB);
 
@@ -364,12 +364,12 @@ How to use entity instance
 ```ts
 
 // operation result
-const total = Money.create(500).value();
+const total = Money.create(500).value() as Money;
 const discount = Money.zero();
 const fees = Money.zero();
 
 // create a payment
-const payment = Payment.create({ total, discount, fees }).value();
+const payment = Payment.create({ total, discount, fees }).value() as Payment;
 
 // create fee and discount
 const fee = Money.create(17.50).value();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "type-ddd",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -53,7 +53,7 @@
 	},
 	"homepage": "https://github.com/4lessandrodev/type-ddd/tree/main",
 	"peerDependencies": {
-		"rich-domain": "^1.23.4"
+		"rich-domain": "^1.24.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^27.0.1",
@@ -65,7 +65,7 @@
 		"lint-staged": "^15.0.1",
 		"madge": "^8.0.0",
 		"prettier": "^3.0.0",
-		"rich-domain": "^1.23.4",
+		"rich-domain": "^1.24.0",
 		"rimraf": "^5.0.5",
 		"ts-jest": "^27.1.4",
 		"ts-node": "^10.7.0",

--- a/packages/cnpj/CHANGELOG.md
+++ b/packages/cnpj/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/cnpj/__tests__/cnpj.value-object.util.spec.ts
+++ b/packages/cnpj/__tests__/cnpj.value-object.util.spec.ts
@@ -10,13 +10,13 @@ describe('CNPJ Value Object', () => {
 		it('should create a valid CNPJ with special characters removed', () => {
 			const valueObject = CNPJValueObject.create('43.909.299/0001-04');
 			expect(valueObject.isOk()).toBeTruthy();
-			expect(valueObject.value().value()).toBe('43909299000104');
+			expect(valueObject.value()?.value()).toBe('43909299000104');
 		});
 
 		it('should create a valid CNPJ with numbers only', () => {
 			const valueObject = CNPJValueObject.create('60105617000101');
 			expect(valueObject.isOk()).toBeTruthy();
-			expect(valueObject.value().value()).toBe('60105617000101');
+			expect(valueObject.value()?.value()).toBe('60105617000101');
 		});
 
 		it('should initialize an instance without error', () => {
@@ -61,25 +61,25 @@ describe('CNPJ Value Object', () => {
 		it('should format a CNPJ with special characters', () => {
 			const valueObject =
 				CNPJValueObject.create('20.798.751/0001-02').value();
-			expect(valueObject.toPattern()).toBe('20.798.751/0001-02');
+			expect(valueObject?.toPattern()).toBe('20.798.751/0001-02');
 		});
 
 		it('should format a CNPJ with special characters', () => {
 			const valueObject =
 				CNPJValueObject.create('65.389.009/0001-81').value();
-			expect(valueObject.toPattern()).toBe('65.389.009/0001-81');
+			expect(valueObject?.toPattern()).toBe('65.389.009/0001-81');
 		});
 
 		it('should format a CNPJ with special characters', () => {
 			const valueObject =
 				CNPJValueObject.create('02.470.431/0001-47').value();
-			expect(valueObject.toPattern()).toBe('02.470.431/0001-47');
+			expect(valueObject?.toPattern()).toBe('02.470.431/0001-47');
 		});
 
 		it('should format a CNPJ with special characters and remove them later', () => {
 			const valueObject =
 				CNPJValueObject.create('62.412.404/0001-40').value();
-			expect(valueObject.toPattern()).toBe('62.412.404/0001-40');
+			expect(valueObject?.toPattern()).toBe('62.412.404/0001-40');
 		});
 	});
 
@@ -89,27 +89,27 @@ describe('CNPJ Value Object', () => {
 			const valueObject = CNPJValueObject.create(validCNPJ).value();
 		
 			// Compare with invalid CNPJ
-			let isEqual = valueObject.compare('invalid');
+			let isEqual = valueObject?.compare('invalid');
 			expect(isEqual).toBeFalsy();
 		
 			// Compare with different valid CNPJ
-			isEqual = valueObject.compare('22.606.062/0001-20');
+			isEqual = valueObject?.compare('22.606.062/0001-20');
 			expect(isEqual).toBeFalsy();
 		
 			// Compare with the same valid CNPJ
-			isEqual = valueObject.compare(validCNPJ);
+			isEqual = valueObject?.compare(validCNPJ);
 			expect(isEqual).toBeTruthy();
 		
 			// Compare with a valid CNPJ with different format
-			isEqual = valueObject.compare('22606062000155');
+			isEqual = valueObject?.compare('22606062000155');
 			expect(isEqual).toBeFalsy();
 		
 			// Compare with a valid CNPJ with the same value but different format
-			isEqual = valueObject.compare('22606062000184');
+			isEqual = valueObject?.compare('22606062000184');
 			expect(isEqual).toBeTruthy();
 		
 			// Compare with the same valid CNPJ
-			isEqual = valueObject.compare('22.606.062/0001-84');
+			isEqual = valueObject?.compare('22.606.062/0001-84');
 			expect(isEqual).toBeTruthy();
 		});
 

--- a/packages/cnpj/index.ts
+++ b/packages/cnpj/index.ts
@@ -111,7 +111,7 @@ export class CNPJ extends ValueObject<string> {
 	 * @example "22398345000188"
 	 * @summary fails if provide an invalid pattern or a cnpj with invalid digit sum
 	 */
-	public static create(value: string): Result<CNPJ> {
+	public static create(value: string): Result<CNPJ | null> {
 		const isValidValue = CNPJ.isValidProps(value);
 
 		if (!isValidValue) {

--- a/packages/cnpj/package.json
+++ b/packages/cnpj/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/cnpj",
   "description": "Library that provides TypeScript type definitions for handling CNPJ (Cadastro Nacional da Pessoa Jurídica) in Domain-Driven Design contexts. It facilitates the validation and manipulation of CNPJ numbers, ensuring they adhere to the Brazilian legal standards.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -33,7 +33,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/cpf/CHANGELOG.md
+++ b/packages/cpf/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/cpf/__tests__/cpf.value-object.util.spec.ts
+++ b/packages/cpf/__tests__/cpf.value-object.util.spec.ts
@@ -9,94 +9,94 @@ describe('cpf.value-object', () => {
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('667.324.914-58');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('66732491458');
+		expect(valueObject.value()?.value()).toBe('66732491458');
 	});
 
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('934.665.143-12');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('93466514312');
+		expect(valueObject.value()?.value()).toBe('93466514312');
 	});
 
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('690.574.738-60');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('69057473860');
+		expect(valueObject.value()?.value()).toBe('69057473860');
 	});
 
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('324.123.359-66');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('32412335966');
+		expect(valueObject.value()?.value()).toBe('32412335966');
 	});
 
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('673.761.543-02');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('67376154302');
+		expect(valueObject.value()?.value()).toBe('67376154302');
 	});
 
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('024.815.901-12');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('02481590112');
+		expect(valueObject.value()?.value()).toBe('02481590112');
 	});
 
 	it('should create a valid cpf with special chars and remove special chars on get value', () => {
 		const valueObject = CPFValueObject.create('754.179.880-06');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('75417988006');
+		expect(valueObject.value()?.value()).toBe('75417988006');
 	});
 
 	it('should format a cpf to add special chars', () => {
 		const valueObject = CPFValueObject.create('667.324.914-58').value();
-		expect(valueObject.toPattern()).toBe('667.324.914-58');
+		expect(valueObject?.toPattern()).toBe('667.324.914-58');
 	});
 
 	it('should format a cpf to add special chars', () => {
 		const valueObject = CPFValueObject.create('578.363.883-87').value();
-		expect(valueObject.toPattern()).toBe('578.363.883-87');
+		expect(valueObject?.toPattern()).toBe('578.363.883-87');
 	});
 
 	it('should format a cpf to add special chars', () => {
 		const valueObject = CPFValueObject.create('844.676.543-80').value();
-		expect(valueObject.toPattern()).toBe('844.676.543-80');
+		expect(valueObject?.toPattern()).toBe('844.676.543-80');
 	});
 
 	it('should format a cpf to add special chars and remove it later', () => {
 		const valueObject = CPFValueObject.create('667.324.914-58').value();
-		expect(valueObject.toPattern()).toBe('667.324.914-58');
-		expect(valueObject.value()).toBe('66732491458');
+		expect(valueObject?.toPattern()).toBe('667.324.914-58');
+		expect(valueObject?.value()).toBe('66732491458');
 	});
 
 	it('should compare value on instance and provided value', () => {
 		const valueObject = CPFValueObject.create('549.777.281-14').value();
-		let isEqual = valueObject.compare('invalid');
+		let isEqual = valueObject?.compare('invalid');
 		expect(isEqual).toBeFalsy();
 
-		isEqual = valueObject.compare('549.777.281-15');
+		isEqual = valueObject?.compare('549.777.281-15');
 		expect(isEqual).toBeFalsy();
 
-		isEqual = valueObject.compare('549.777.281-14');
+		isEqual = valueObject?.compare('549.777.281-14');
 		expect(isEqual).toBeTruthy();
 
-		isEqual = valueObject.compare('54977728314');
+		isEqual = valueObject?.compare('54977728314');
 		expect(isEqual).toBeFalsy();
 
-		isEqual = valueObject.compare('54977728114');
+		isEqual = valueObject?.compare('54977728114');
 		expect(isEqual).toBeTruthy();
 
-		isEqual = valueObject.compare('54977728114');
+		isEqual = valueObject?.compare('54977728114');
 		expect(isEqual).toBeTruthy();
 
-		isEqual = valueObject.compare('549.777.281-14');
+		isEqual = valueObject?.compare('549.777.281-14');
 		expect(isEqual).toBeTruthy();
 	});
 
 	it('should create a valid cpf only numbers', () => {
 		const valueObject = CPFValueObject.create('53534317661');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('53534317661');
+		expect(valueObject.value()?.value()).toBe('53534317661');
 		expect(CPFValueObject.isValid('53534317661')).toBeTruthy();
 	});
 
@@ -118,13 +118,13 @@ describe('cpf.value-object', () => {
 	it('should create a valid cpf only numbers', () => {
 		const valueObject = CPFValueObject.create('53534317661');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('53534317661');
+		expect(valueObject.value()?.value()).toBe('53534317661');
 	});
 
 	it('should create a valid cpf only numbers', () => {
 		const valueObject = CPFValueObject.create('98614591039');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('98614591039');
+		expect(valueObject.value()?.value()).toBe('98614591039');
 	});
 
 	it('should init an instance with success', () => {

--- a/packages/cpf/index.ts
+++ b/packages/cpf/index.ts
@@ -107,7 +107,7 @@ export class CPF extends ValueObject<string> {
 	 * @example "72725477824"
 	 * @summary fails if provide an invalid pattern or a cpf with invalid digit sum
 	 */
-	public static create(value: string): Result<CPF> {
+	public static create(value: string): Result<CPF | null> {
 		const isValidValue = CPF.isValidProps(value);
 
 		if (!isValidValue) {

--- a/packages/cpf/package.json
+++ b/packages/cpf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/cpf",
   "description": "This package provides TypeScript type definitions for handling CPF (Cadastro de Pessoa Física) in Domain-Driven Design contexts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -30,7 +30,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/date/__tests__/date.value-object.spec.ts
+++ b/packages/date/__tests__/date.value-object.spec.ts
@@ -20,7 +20,7 @@ describe('Date', () => {
 
 		it('should create an instance with success', () => {
 			const instance = Dates.create(new Date(2020, 1, 1, 1, 1, 1));
-			expect(instance.value().value().toISOString()).toBe('2020-02-01T01:01:01.000Z');
+			expect(instance.value()?.value().toISOString()).toBe('2020-02-01T01:01:01.000Z');
 		});
 
 		it('should return result fail if provide an invalid value', () => {

--- a/packages/date/index.ts
+++ b/packages/date/index.ts
@@ -515,7 +515,7 @@ export class Dates extends ValueObject<Date> {
 	 * @param value value as Date or date string or number as timestamp
 	 * @returns Result of Dates
 	 */
-	public static create(date?: Date | string | number): Result<Dates> {
+	public static create(date?: Date | string | number): Result<Dates | null> {
 		const value = date ?? new Date();
 		const isValid = Dates.isValidProps(value);
 		if (!isValid) return Result.fail(Dates.MESSAGE);

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/date",
   "description": "Library that provides TypeScript type definitions for handling Dates in Domain-Driven Design contexts. It facilitates the validation and manipulation of Dates.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -29,7 +29,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/email/CHANGELOG.md
+++ b/packages/email/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [0.0.4] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
+---
+
 ### [0.0.3] - 2024-09-26
 
 ### Fix

--- a/packages/email/__tests__/email.value-object.spec.ts
+++ b/packages/email/__tests__/email.value-object.spec.ts
@@ -55,14 +55,14 @@ describe('email-value-object.util', () => {
 		const valueObject = EmailValueObject.create(
 			'Valid_EmaiL@Domain.Com',
 		).value();
-		expect(valueObject.value()).toBe('valid_email@domain.com');
+		expect(valueObject?.value()).toBe('valid_email@domain.com');
 	});
 
 	it('should create and get value from a valid email with success', () => {
 		const valueObject = EmailValueObject.create(
 			'valid_email@domain.com',
 		).value();
-		expect(valueObject.value()).toBe('valid_email@domain.com');
+		expect(valueObject?.value()).toBe('valid_email@domain.com');
 	});
 
 	it('should to be a valid email', () => {
@@ -70,7 +70,7 @@ describe('email-value-object.util', () => {
 			'test-email-124@domain.com',
 		);
 		expect(valueObject.isOk()).toBe(true);
-		expect(valueObject.value().value()).toBe('test-email-124@domain.com');
+		expect(valueObject.value()?.value()).toBe('test-email-124@domain.com');
 	});
 
 	it('should to be a valid email', () => {
@@ -78,7 +78,7 @@ describe('email-value-object.util', () => {
 			'test-some-value-12@domain.name',
 		);
 		expect(valueObject.isOk()).toBe(true);
-		expect(valueObject.value().value()).toBe(
+		expect(valueObject.value()?.value()).toBe(
 			'test-some-value-12@domain.name',
 		);
 	});
@@ -141,14 +141,14 @@ describe('email-value-object.util', () => {
 		const valueObject = EmailValueObject.create(
 			'username@domain.com',
 		).value();
-		expect(valueObject.nick()).toBe('username');
+		expect(valueObject?.nick()).toBe('username');
 	});
 
 	it('should get domain', () => {
 		const valueObject = EmailValueObject.create(
 			'username@domain.com',
 		).value();
-		expect(valueObject.domain()).toBe('domain.com');
+		expect(valueObject?.domain()).toBe('domain.com');
 	});
 
 	it('should create value object with success', () => {
@@ -156,7 +156,7 @@ describe('email-value-object.util', () => {
 			'username.nickname@domain.com',
 		);
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe(
+		expect(valueObject.value()?.value()).toBe(
 			'username.nickname@domain.com',
 		);
 	});
@@ -164,25 +164,25 @@ describe('email-value-object.util', () => {
 	it('should create value object with success', () => {
 		const valueObject = EmailValueObject.create('rocio65@gmail.com');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('rocio65@gmail.com');
+		expect(valueObject.value()?.value()).toBe('rocio65@gmail.com');
 	});
 
 	it('should create value object with success', () => {
 		const valueObject = EmailValueObject.create('user_nick2.0@hotmail.com');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('user_nick2.0@hotmail.com');
+		expect(valueObject.value()?.value()).toBe('user_nick2.0@hotmail.com');
 	});
 
 	it('should create value object with success', () => {
 		const valueObject = EmailValueObject.create('rocio_65@gmail.com');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('rocio_65@gmail.com');
+		expect(valueObject.value()?.value()).toBe('rocio_65@gmail.com');
 	});
 
 	it('should create value object with success', () => {
 		const valueObject = EmailValueObject.create('4you@gmail.com');
 		expect(valueObject.isOk()).toBeTruthy();
-		expect(valueObject.value().value()).toBe('4you@gmail.com');
+		expect(valueObject.value()?.value()).toBe('4you@gmail.com');
 	});
 
 	it('should fails if not provide a domain', () => {
@@ -211,13 +211,13 @@ describe('email-value-object.util', () => {
 
 	it('should get domain with success', () => {
 		const vo = EmailValueObject.create('my-email@domain.com').value();
-		expect(vo.domain()).toBe('domain.com');
+		expect(vo?.domain()).toBe('domain.com');
 	});
 
 	it('should get nick with success', () => {
 		const vo = EmailValueObject.create('my-email@domain.com').value();
-		expect(vo.get('value')).toBe('my-email@domain.com');
-		expect(vo.nick()).toBe('my-email');
+		expect(vo?.get('value')).toBe('my-email@domain.com');
+		expect(vo?.nick()).toBe('my-email');
 	});
 
 	it('should to be a valid domain', () => {

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -72,7 +72,7 @@ export class Email extends ValueObject<string> {
 		return new Email(value.toLowerCase());
 	}
 
-	public static create(value: string): Result<Email> {
+	public static create(value: string): Result<Email | null> {
 		if (!Email.isValidProps(value)) {
 			return Result.fail(Email.MESSAGE);
 		}

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/email",
   "description": "Library that provides TypeScript type definitions for handling Email in Domain-Driven Design contexts. It facilitates the validation and manipulation of emails.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -29,7 +29,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/money/CHANGELOG.md
+++ b/packages/money/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/money/index.ts
+++ b/packages/money/index.ts
@@ -503,7 +503,7 @@ class Money extends ValueObject<number> {
 	 * @param value The initial value for the Money object.
 	 * @returns A Result object containing either a Money object or an error message.
 	 */
-	public static create(value: number): Result<Money> {
+	public static create(value: number): Result<Money | null> {
 		if (!Money.isValidProps(value)) {
 			return Result.fail(Money.MESSAGE);
 		}

--- a/packages/money/package.json
+++ b/packages/money/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/money",
   "description": "This package provides TypeScript type definitions for handling Money in Domain-Driven Design contexts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -30,7 +30,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/password/CHANGELOG.md
+++ b/packages/password/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.4] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.3] - 2024-09-26
 
 ### Fix

--- a/packages/password/__tests__/password.spec.ts
+++ b/packages/password/__tests__/password.spec.ts
@@ -42,23 +42,23 @@ describe('password.value-object', () => {
 
 		it('should validate encrypted password with success', () => {
 			const result = PasswordValueObject.create('123456').value();
-			const encrypted = result.encrypt();
-			const isEncrypted = encrypted.isEncrypted();
+			const encrypted = result?.encrypt();
+			const isEncrypted = encrypted?.isEncrypted();
 			expect(isEncrypted).toBe(true);
-			expect(PasswordValueObject.isValid(encrypted.value())).toBe(true);
+			expect(PasswordValueObject.isValid(encrypted?.value() as string)).toBe(true);
 		});
 
 		it('should encrypt password with success', () => {
 			const result = PasswordValueObject.create('123456').value();
-			expect(result.isEncrypted()).toBe(false);
-			const encrypted = result.encrypt();
-			const isEncrypted = encrypted.isEncrypted();
+			expect(result?.isEncrypted()).toBe(false);
+			const encrypted = result?.encrypt();
+			const isEncrypted = encrypted?.isEncrypted();
 			expect(isEncrypted).toBe(true);
 		});
 
 		it('should get value result with success', () => {
 			const result = PasswordValueObject.create('123456').value();
-			expect(result.value()).toBe('123456');
+			expect(result?.value()).toBe('123456');
 		});
 
 		it('should generate a valid random password not encrypted', () => {
@@ -77,9 +77,9 @@ describe('password.value-object', () => {
 		it('should password to be equal', () => {
 			const passA = PasswordValueObject.create('123456abc!').value();
 			const passC = PasswordValueObject.create('123456abc!').value();
-			const passB = passA.clone();
-			const isEqual1 = passA.isEqual(passB);
-			const isEqual2 = passA.isEqual(passC);
+			const passB = passA?.clone();
+			const isEqual1 = passA?.isEqual(passB as PasswordValueObject);
+			const isEqual2 = passA?.isEqual(passC as PasswordValueObject);
 			expect(isEqual1).toBe(true);
 			expect(isEqual2).toBe(true);
 		});
@@ -93,39 +93,39 @@ describe('password.value-object', () => {
 
 		it('should compare password not encrypted', () => {
 			const result = PasswordValueObject.create('123456').value();
-			const match = result.compare('123456');
+			const match = result?.compare('123456');
 			expect(match).toBeTruthy();
 		});
 
 		it('should compare encrypted password', () => {
 			const result = PasswordValueObject.create('123456').value();
-			const encrypted = result.encrypt();
-			const match = encrypted.compare('123456');
+			const encrypted = result?.encrypt();
+			const match = encrypted?.compare('123456');
 			expect(match).toBeTruthy();
 		});
 
 		it('should compare password not encrypted', () => {
 			const result = PasswordValueObject.create('123456').value();
-			const match = result.compare('abcdef');
+			const match = result?.compare('abcdef');
 			expect(match).toBeFalsy();
 		});
 
 		it('should compare encrypted password', () => {
 			const result = PasswordValueObject.create('123456').value();
-			const encrypted = result.encrypt();
-			const match = encrypted.compare('abcdef');
+			const encrypted = result?.encrypt();
+			const match = encrypted?.compare('abcdef');
 			expect(match).toBeFalsy();
 		});
 
 		it('should encrypt many times and keep value', () => {
 			const valueObject = PasswordValueObject.create('12345').value();
-			expect(valueObject.isEncrypted()).toBeFalsy();
-			const encrypted1 = valueObject.encrypt();
-			expect(encrypted1.isEncrypted()).toBeTruthy();
-			expect(valueObject.compare('12345')).toBeTruthy();
+			expect(valueObject?.isEncrypted()).toBeFalsy();
+			const encrypted1 = valueObject?.encrypt();
+			expect(encrypted1?.isEncrypted()).toBeTruthy();
+			expect(valueObject?.compare('12345')).toBeTruthy();
 
-			expect(encrypted1.compare('12345')).toBe(true);
-			expect(encrypted1.isEncrypted()).toBeTruthy();
+			expect(encrypted1?.compare('12345')).toBe(true);
+			expect(encrypted1?.isEncrypted()).toBeTruthy();
 		});
 	});
 

--- a/packages/password/index.ts
+++ b/packages/password/index.ts
@@ -123,7 +123,7 @@ class Password extends ValueObject<string> {
 	 * @param value password to create
 	 * @returns Result of PasswordValueObject
 	 */
-	static create(value: string): Result<Password> {
+	static create(value: string): Result<Password | null> {
 		if (!Password.isValidProps(value)) {
 			return Result.fail(Password.MESSAGE);
 		}

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/password",
   "description": "Library that provides TypeScript type definitions for handling Password in Domain-Driven Design contexts. It facilitates the validation and manipulation of passwords.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "bcrypt": "^5.0.1",
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/patterns",
   "description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -32,7 +32,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/phone/CHANGELOG.md
+++ b/packages/phone/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/phone/__tests__/home-phone.value-object.spec.ts
+++ b/packages/phone/__tests__/home-phone.value-object.spec.ts
@@ -64,21 +64,21 @@ describe('home-phone.value-object', () => {
 	it('should get value', () => {
 		const valueObject =
 			HomePhoneValueObject.create('(71) 2254-1211').value();
-		expect(valueObject.value()).toBe('7122541211');
-		expect(valueObject.toPattern()).toBe('(71) 2254-1211');
+		expect(valueObject?.value()).toBe('7122541211');
+		expect(valueObject?.toPattern()).toBe('(71) 2254-1211');
 	});
 
 	it('should get only numbers value', () => {
 		const valueObject =
 			HomePhoneValueObject.create('(71) 2254-1211').value();
-		expect(valueObject.number()).toBe('22541211');
-		expect(valueObject.toCall()).toBe('07122541211');
+		expect(valueObject?.number()).toBe('22541211');
+		expect(valueObject?.toCall()).toBe('07122541211');
 	});
 
 	it('should get only DDD number', () => {
 		const valueObject =
 			HomePhoneValueObject.create('(71) 2254-1211').value();
-		expect(valueObject.code()).toBe(71);
+		expect(valueObject?.code()).toBe(71);
 	});
 
 	it('should init an instance with success', () => {

--- a/packages/phone/__tests__/mobile-phone.value-object.spec.ts
+++ b/packages/phone/__tests__/mobile-phone.value-object.spec.ts
@@ -69,21 +69,21 @@ describe('home-phone.value-object', () => {
 	it('should get value', () => {
 		const valueObject =
 			MobilePhoneValueObject.create('(71) 98254-1211').value();
-		expect(valueObject.value()).toBe('71982541211');
-		expect(valueObject.toPattern()).toBe('(71) 98254-1211');
+		expect(valueObject?.value()).toBe('71982541211');
+		expect(valueObject?.toPattern()).toBe('(71) 98254-1211');
 	});
 
 	it('should get only numbers value', () => {
 		const valueObject =
 			MobilePhoneValueObject.create('(71) 96254-1211').value();
-		expect(valueObject.number()).toBe('962541211');
-		expect(valueObject.toCall()).toBe('071962541211')
+		expect(valueObject?.number()).toBe('962541211');
+		expect(valueObject?.toCall()).toBe('071962541211')
 	});
 
 	it('should get only DDD number', () => {
 		const valueObject =
 			MobilePhoneValueObject.create('(71) 97254-1211').value();
-		expect(valueObject.code()).toBe(71);
+		expect(valueObject?.code()).toBe(71);
 	});
 
 	it('should init an instance with success', () => {

--- a/packages/phone/__tests__/phone.value-object.spec.ts
+++ b/packages/phone/__tests__/phone.value-object.spec.ts
@@ -29,14 +29,14 @@ describe('phone', () => {
 
     it('should create a valid phone', () => {
         const phone = Phone.create('(11) 3404-2885').value();
-        expect(phone.isHome()).toBeTruthy();
-        expect(phone.isMobile()).toBeFalsy();
+        expect(phone?.isHome()).toBeTruthy();
+        expect(phone?.isMobile()).toBeFalsy();
     });
 
     it('should create a valid phone', () => {
         const phone = Phone.create('(11) 99488-2885').value();
-        expect(phone.isHome()).toBeFalsy();
-        expect(phone.isMobile()).toBeTruthy();
+        expect(phone?.isHome()).toBeFalsy();
+        expect(phone?.isMobile()).toBeTruthy();
     });
 
     it('should return fail', () => {

--- a/packages/phone/home.value-object.ts
+++ b/packages/phone/home.value-object.ts
@@ -118,7 +118,7 @@ class HomePhone extends ValueObject<string> {
 	 * @example (XX) XXXX-XXXX
 	 * @returns Result of HomePhoneValueObject
 	 */
-	public static create(value: string): Result<HomePhone> {
+	public static create(value: string): Result<HomePhone | null> {
 		if (!HomePhone.isValidProps(value)) {
 			return Result.fail(HomePhone.MESSAGE);
 		}

--- a/packages/phone/mobile.value-object.ts
+++ b/packages/phone/mobile.value-object.ts
@@ -120,7 +120,7 @@ class MobilePhone extends ValueObject<string> {
 	 * @example (XX) 9XXXX-XXXX
 	 * @returns Result of MobilePhoneValueObject
 	 */
-	public static create(value: string): Result<MobilePhone> {
+	public static create(value: string): Result<MobilePhone | null> {
 		if (!MobilePhone.isValidProps(value)) {
 			return Result.fail(MobilePhone.MESSAGE);
 		}

--- a/packages/phone/package.json
+++ b/packages/phone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/phone",
   "description": "Library that provides TypeScript type definitions for handling Phone Numbers in Domain-Driven Design contexts. It facilitates the validation and manipulation of Brazilian phone numbers.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -31,7 +31,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/phone/phone.value-object.ts
+++ b/packages/phone/phone.value-object.ts
@@ -70,7 +70,7 @@ export class Phone extends ValueObject<string> {
      * @example (XX) 9XXXX-XXXX or (XX) 3XXX-XXXX
      * @returns Result of MobilePhone or HomePhone
      */
-    public static create(value: string): Result<MobilePhone | HomePhone> {
+    public static create(value: string): Result<MobilePhone | HomePhone | null> {
         const isValid = this.isValidProps(value);
         if (!isValid) return Result.fail(this.MESSAGE);
         const isMobile = this.isMobile(value);

--- a/packages/type-ddd/CHANGELOG.md
+++ b/packages/type-ddd/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.5] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.4] - 2024-09-26
 
 ### Fix

--- a/packages/type-ddd/package.json
+++ b/packages/type-ddd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/core",
   "description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -13,17 +13,17 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@type-ddd/cnpj": "^0.0.2",
-    "@type-ddd/cpf": "^0.0.2",
-    "@type-ddd/date": "^0.0.2",
-    "@type-ddd/email": "^0.0.3",
-    "@type-ddd/money": "^0.0.2",
-    "@type-ddd/password": "^0.0.3",
-    "@type-ddd/patterns": "^0.0.2",
-    "@type-ddd/phone": "^0.0.2",
-    "@type-ddd/username": "^0.0.2",
-    "@type-ddd/zip-code": "^0.0.2",
-    "rich-domain": "^1.23.4"
+    "@type-ddd/cnpj": "^0.0.3",
+    "@type-ddd/cpf": "^0.0.3",
+    "@type-ddd/date": "^0.0.3",
+    "@type-ddd/email": "^0.0.4",
+    "@type-ddd/money": "^0.0.3",
+    "@type-ddd/password": "^0.0.4",
+    "@type-ddd/patterns": "^0.0.3",
+    "@type-ddd/phone": "^0.0.3",
+    "@type-ddd/username": "^0.0.3",
+    "@type-ddd/zip-code": "^0.0.3",
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/username/CHANGELOG.md
+++ b/packages/username/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/username/__tests__/user-name-value-object.util.spec.ts
+++ b/packages/username/__tests__/user-name-value-object.util.spec.ts
@@ -13,7 +13,7 @@ describe('user-name.value-object', () => {
 
 	it('should get value', () => {
 		const username = UserName.create('valid username').value();
-		expect(username.value()).toBe('Valid Username');
+		expect(username?.value()).toBe('Valid Username');
 	});
 
 	it('should fail if provide a long name (41) chars', () => {
@@ -31,130 +31,130 @@ describe('user-name.value-object', () => {
 	it('should get first name with success', () => {
 		const username =
 			UserName.create('first middle last').value();
-		expect(username.firstName()).toBe('First');
+		expect(username?.firstName()).toBe('First');
 	});
 
 	it('should check if has last name [false]', () => {
 		const username = UserName.create('first').value();
-		expect(username.hasLastName()).toBe(false);
+		expect(username?.hasLastName()).toBe(false);
 	});
 
 	it('should check if has last name [true]', () => {
 		const username =
 			UserName.create('first middle last').value();
-		expect(username.hasLastName()).toBe(true);
+		expect(username?.hasLastName()).toBe(true);
 	});
 
 	it('should check if has last name [true]', () => {
 		const username = UserName.create('first last').value();
-		expect(username.hasLastName()).toBe(true);
+		expect(username?.hasLastName()).toBe(true);
 	});
 
 	it('should check if has middle name [false]', () => {
 		const username = UserName.create('first').value();
-		expect(username.hasMiddleName()).toBe(false);
+		expect(username?.hasMiddleName()).toBe(false);
 	});
 
 	it('should check if has middle name [true]', () => {
 		const username =
 			UserName.create('first middle last').value();
-		expect(username.hasMiddleName()).toBe(true);
+		expect(username?.hasMiddleName()).toBe(true);
 	});
 
 	it('should get first name', () => {
 		const username = UserName.create('first middle last').value();
-		expect(username.firstName()).toBe('First');
+		expect(username?.firstName()).toBe('First');
 	});
 
 	it('should get first name', () => {
 		const username = UserName.create('first middle').value();
-		expect(username.firstName()).toBe('First');
+		expect(username?.firstName()).toBe('First');
 	});
 
 	it('should get first name', () => {
 		const username = UserName.create('first').value();
-		expect(username.firstName()).toBe('First');
+		expect(username?.firstName()).toBe('First');
 	});
 
 	it('should get middle name', () => {
 		const username = UserName.create('first middle last').value();
-		expect(username.middleName()).toBe('Middle');
+		expect(username?.middleName()).toBe('Middle');
 	});
 
 	it('should NOT get middle name', () => {
 		const username = UserName.create('first last').value();
-		expect(username.middleName()).toBe('');
+		expect(username?.middleName()).toBe('');
 	});
 
 	it('should get last name', () => {
 		const username = UserName.create('first last').value();
-		expect(username.lastName()).toBe('Last');
+		expect(username?.lastName()).toBe('Last');
 	});
 
 	it('should return the first if does not exist last name', () => {
 		const username = UserName.create('FIRST').value();
-		expect(username.lastName()).toBe('First');
+		expect(username?.lastName()).toBe('First');
 	});
 
 	it('should capitalize names', () => {
 		const username = UserName.create('first middle last').value();
-		expect(username.value()).toBe('First Middle Last');
+		expect(username?.value()).toBe('First Middle Last');
 	});
 
 	it('should capitalize names', () => {
 		const username = UserName.create('FIRST MIDDLE LAST').value();
-		expect(username.value()).toBe('First Middle Last');
-		expect(username.get('value')).toBe('First Middle Last');
+		expect(username?.value()).toBe('First Middle Last');
+		expect(username?.get('value')).toBe('First Middle Last');
 	});
 
 	it('should get initials', () => {
 		const username = UserName.create('FIRST MIDDLE LAST').value();
-		expect(username.initials()).toBe('FML');
+		expect(username?.initials()).toBe('FML');
 	});
 
 	it('should get initials with custom separator', () => {
 		const separator = '-';
 		const username = UserName.create('FIRST MIDDLE LAST').value();
-		expect(username.initials(separator)).toBe('F-M-L');
+		expect(username?.initials(separator)).toBe('F-M-L');
 	});
 
 	it('should get initials with none separator', () => {
 		const separator = '.';
 		const username = UserName.create('FIRST MIDDLE LAST').value();
-		expect(username.initials(separator)).toBe('F.M.L');
+		expect(username?.initials(separator)).toBe('F.M.L');
 	});
 
 	it('should get initials', () => {
 		const username = UserName.create('FIRSt').value();
-		expect(username.initials()).toBe('F');
+		expect(username?.initials()).toBe('F');
 	});
 
 	it('should name with duple spaces', () => {
 		const username = UserName.create(
 			'José caleb  dos Santos',
 		).value();
-		expect(username.value()).toBe('José Caleb Dos Santos');
+		expect(username?.value()).toBe('José Caleb Dos Santos');
 	});
 
 	it('should name with duple spaces and two character "de" ', () => {
 		const username = UserName.create(
 			'José caleb  de Oliveira',
 		).value();
-		expect(username.value()).toBe('José Caleb De Oliveira');
+		expect(username?.value()).toBe('José Caleb De Oliveira');
 	});
 
 	it('should name with duple spaces and two character specials ', () => {
 		const username = UserName.create(
 			'José caleb , de Oliveira',
 		).value();
-		expect(username.value()).toBe('José Caleb De Oliveira');
+		expect(username?.value()).toBe('José Caleb De Oliveira');
 	});
 
 	it('should name with three spaces in name', () => {
 		const username = UserName.create(
 			'José caleb   de Oliveira',
 		).value();
-		expect(username.value()).toBe('José Caleb De Oliveira');
+		expect(username?.value()).toBe('José Caleb De Oliveira');
 	});
 
 	it('should init an instance with success', () => {

--- a/packages/username/index.ts
+++ b/packages/username/index.ts
@@ -158,7 +158,7 @@ export class UserName extends ValueObject<string> {
 		);
 	}
 
-	public static create(value: string): Result<UserName> {
+	public static create(value: string): Result<UserName | null> {
 		const isValidValue = UserName.isValidProps(value);
 		if (!isValidValue) {
 			return Result.fail(UserName.MESSAGE);

--- a/packages/username/package.json
+++ b/packages/username/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/username",
   "description": "This package provides TypeScript type definitions for handling User Name in Domain-Driven Design contexts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -30,7 +30,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/packages/zip-code/CHANGELOG.md
+++ b/packages/zip-code/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Released
 
+---
+
+### [0.0.3] - 2024-11-28
+
+### Fix
+
+- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
+
 ### [0.0.2] - 2024-05-31
 
 ### Docs

--- a/packages/zip-code/__tests__/zip-code.value-object.spec.ts
+++ b/packages/zip-code/__tests__/zip-code.value-object.spec.ts
@@ -24,12 +24,12 @@ describe('postal-code.value-object', () => {
 
 	it('should get value', () => {
 		const valueObject = ZipCodeValueObject.create('75520140').value();
-		expect(valueObject.value()).toBe('75520140');
+		expect(valueObject?.value()).toBe('75520140');
 	});
 
 	it('should get value without hyphen', () => {
 		const valueObject = ZipCodeValueObject.create('75520-140').value();
-		expect(valueObject.value()).toBe('75520140');
+		expect(valueObject?.value()).toBe('75520140');
 	});
 
 	it('should fail if provide an invalid postal code', () => {

--- a/packages/zip-code/index.ts
+++ b/packages/zip-code/index.ts
@@ -77,7 +77,7 @@ class ZipCode extends ValueObject<string> {
 	}
 
 
-	public static create(value: string): Result<ZipCode> {
+	public static create(value: string): Result<ZipCode | null> {
 		if (!ZipCode.isValidProps(value)) {
 			return Result.fail(ZipCode.MESSAGE);
 		}

--- a/packages/zip-code/package.json
+++ b/packages/zip-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-ddd/zip-code",
   "description": "This package provides TypeScript type definitions for handling Brazilian Zip Code in Domain-Driven Design contexts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "Alessandro Dev",
@@ -31,7 +31,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "rich-domain": "^1.23.4"
+    "rich-domain": "^1.24.0"
   },
   "files": [
     "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5856,10 +5856,10 @@ rfdc@^1.4.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rich-domain@^1.23.4:
-  version "1.23.4"
-  resolved "https://registry.yarnpkg.com/rich-domain/-/rich-domain-1.23.4.tgz#14341114f0df36a137419d4bad0252f324b7c85f"
-  integrity sha512-k0KdYb84a+r7wwJz0a4QGIRDYu2LrA2bPEhXq2d4wqEIsRmTK/KCm/0hq3QYCZxqxh9Z9C/A/3N/X/TToL9EBA==
+rich-domain@^1.24.0:
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/rich-domain/-/rich-domain-1.24.0.tgz#a0eabb0357c822daf9a39143d7355073fcbb97ed"
+  integrity sha512-gMXpnTxrfJeqWfosU6gouYG+rdPQ1BuK925vCB2Q5Ov+mxxzhIehftvLs6BhL8BZusDJn6JFfzvnIVh3fZmMVg==
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### [4.0.5] - 2024-11-28

### Fix

- update rich-domain lib to check nullish type: now 'create' return a possibly null value in Result instance.
